### PR TITLE
Update deps for node v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,16 +7,16 @@
     "test": "test"
   },
   "dependencies": {
-    "aws-sdk": "2.2.20",
-    "archiver": "0.20.0",
-    "bluebird": "3.0.6",
+    "aws-sdk": "2.6.12",
+    "archiver": "1.1.0",
+    "bluebird": "3.4.6",
     "mongo-uri": "0.1.2",
-    "mongodb": "2.0.49",
+    "mongodb": "2.2.11",
     "s3-upload-stream": "1.0.7"
   },
   "devDependencies": {
-    "mocha": "2.3.4",
-    "eslint": "1.10.3"
+    "mocha": "3.1.2",
+    "eslint": "3.8.1"
   },
   "scripts": {
     "test": "mocha -b"

--- a/test/index.js
+++ b/test/index.js
@@ -3,7 +3,7 @@ var mongodump = require('../index');
 describe('mongudump test suite', function() {
   this.timeout(100000);
   it('work', function(done) {
-    return mongodump({
+    mongodump({
       uri: process.env.MONGO_URI,
       s3: {
         accessKeyId: process.env.AWS_ACCESS_KEY_ID,
@@ -11,11 +11,6 @@ describe('mongudump test suite', function() {
         bucket: process.env.AWS_S3_DUMP_BUCKET,
         key: process.env.AWS_S3_DUMP_KEY
       }
-    }).then(function() {
-      done();
-    }).catch(function(err) {
-      console.error(err.trace);
-      done(err);
-    });
+    }).asCallback(done);
   });
 });


### PR DESCRIPTION
Update deps for node v6
I updated all deps to latest but only `mongodb` / `archiver` was breaking 